### PR TITLE
Fix GitHub Service Status Method

### DIFF
--- a/app/ai/github_service.py
+++ b/app/ai/github_service.py
@@ -281,6 +281,33 @@ class GitHubService:
         self.branches_cache = {}
         self.files_cache = {}
         return True
+        
+    def get_status(self):
+        """Get the status of the GitHub service."""
+        token = self.get_token()
+        if not token:
+            return {
+                "connected": False,
+                "message": "GitHub token not set",
+                "user": None
+            }
+            
+        # Check if we can connect to GitHub
+        user_info = self.get_user_info()
+        if "error" in user_info:
+            return {
+                "connected": False,
+                "message": user_info.get("error", "Failed to connect to GitHub"),
+                "user": None
+            }
+            
+        return {
+            "connected": True,
+            "message": "Connected to GitHub",
+            "user": user_info.get("login"),
+            "avatar_url": user_info.get("avatar_url"),
+            "html_url": user_info.get("html_url")
+        }
 
 # Singleton instance
 github_service = GitHubService()


### PR DESCRIPTION
This PR fixes the error in the GitHub service by adding the missing `get_status` method to the `GitHubService` class.

The error was occurring because the `get_status` method was being called in the routes but was not implemented in the `GitHubService` class. This PR adds the method with proper implementation to check GitHub connectivity and user information.